### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import padkontrol
 ```
 
 See `example.py` for more in-depth usage.
-The example uses [rtmidi-python](https://github.com/superquadratic/rtmidi-python) for MIDI IO.
+The example uses [python-rtmidi](http://trac.chrisarndt.de/code/wiki/python-rtmidi) for MIDI IO.
 You will probably have to modify the OUTPUT_MIDI_PORT and INPUT_MIDI_PORT variables.
 
 # Acknowledgements

--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
+# padkontrol
 Version 1.0
 
-padkontrol
-==========
-
-By Stuart Keith.
+By Stuart Keith
 
 padkontrol is a Python module used to interact with the Korg PadKontrol MIDI controller via its native mode.
 
-See example.py for usage. The example uses [rtmidi-python](https://github.com/superquadratic/rtmidi-python) for MIDI IO. You will probably have to modify the OUTPUT_MIDI_PORT and INPUT_MIDI_PORT variables.
+# How to use
+First install the module
+```shell
+pip install "git+https://github.com/stuartkeith/padkontrol.git"
+```
 
+Now simply import the module and you're all set
+```python
+import padkontrol
+```
+
+See `example.py` for more in-depth usage.
+The example uses [rtmidi-python](https://github.com/superquadratic/rtmidi-python) for MIDI IO.
+You will probably have to modify the OUTPUT_MIDI_PORT and INPUT_MIDI_PORT variables.
+
+# Acknowledgements
 Thanks to h2a2p for writing the "Guide to PadKontrol Native Mode - Version 2.1" PDF (downloaded from [http://www.korgforums.com/forum/phpBB2/viewtopic.php?t=28030](http://www.korgforums.com/forum/phpBB2/viewtopic.php?t=28030)).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-rtmidi==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name='padkontrol',
+      version='1.0.0',
+      description='Module to interact with the Korg PadKontrol MIDI controller via its native mode',
+      url='https://github.com/stuartkeith/padkontrol',
+      author='Stuart Keith',
+      author_email='stuartjkeith@gmail.com',
+      zip_safe=True,
+      py_modules=['padkontrol'])


### PR DESCRIPTION
By updating to python-rtmidi, which is maintained :)
Also fixed wrong location of `sysex_buffer` declaration which caused the `midi_in_callback` to fail

@stuartkeith not sure if you still use this or not, but I though I might as well make a PR for the issues I ran into :)

This PR is actually based on the code (actually the readme changes) in #2, I'll rebase this PR if #2 is merged.