### PR TITLE
Add setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
+# padkontrol
 Version 1.0
 
-padkontrol
-==========
-
-By Stuart Keith.
+By Stuart Keith
 
 padkontrol is a Python module used to interact with the Korg PadKontrol MIDI controller via its native mode.
 
-See example.py for usage. The example uses [rtmidi-python](https://github.com/superquadratic/rtmidi-python) for MIDI IO. You will probably have to modify the OUTPUT_MIDI_PORT and INPUT_MIDI_PORT variables.
+# How to use
+First install the module
+```shell
+pip install "git+https://github.com/stuartkeith/padkontrol.git"
+```
 
+Now simply import the module and you're all set
+```python
+import padkontrol
+```
+
+See `example.py` for more in-depth usage.
+The example uses [rtmidi-python](https://github.com/superquadratic/rtmidi-python) for MIDI IO.
+You will probably have to modify the OUTPUT_MIDI_PORT and INPUT_MIDI_PORT variables.
+
+# Acknowledgements
 Thanks to h2a2p for writing the "Guide to PadKontrol Native Mode - Version 2.1" PDF (downloaded from [http://www.korgforums.com/forum/phpBB2/viewtopic.php?t=28030](http://www.korgforums.com/forum/phpBB2/viewtopic.php?t=28030)).

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name='padkontrol',
+      version='1.0.0',
+      description='Module to interact with the Korg PadKontrol MIDI controller via its native mode',
+      url='https://github.com/stuartkeith/padkontrol',
+      author='Stuart Keith',
+      author_email='stuartjkeith@gmail.com',
+      zip_safe=True,
+      py_modules=['padkontrol'])


### PR DESCRIPTION
Another small one, since `setup.py` was missing it was kind of difficult to include the padkontrol module in another project. Adding a `setup.py` allows one to install this module using pip
```
pip install "git+https://github.com/stuartkeith/padkontrol.git" 
```

If you want to try it
```
pip install "git+https://github.com/simonvanderveldt/padkontrol.git@add-setup-py"
```